### PR TITLE
cli not main

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The game Snake implemented with functional style in JavaScript without libraries
 ```bash
 git clone git@github.com:chrokh/snake.git
 cd snake
-node main
+node cli
 ```
 
 - Use arrow keys, wasd, or hjkl to control the snake.


### PR DESCRIPTION
When I try running 'node main' my command line reports:
module.js:549
    throw err;
    ^

Error: Cannot find module 'C:\...\snake\main'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3

So I guessed that 'main' here was referring to a file name, and when I ran 'node cli' it worked fine.